### PR TITLE
Fixing Canonical meta tags

### DIFF
--- a/src/Extension/SEODataExtension.php
+++ b/src/Extension/SEODataExtension.php
@@ -254,7 +254,7 @@ class SEODataExtension extends DataExtension
 		if($canonical = $record->obj('CanonicalURL')->getValue()) {
 			$tags['canonical'] = $raw ? $canonical : HTML::createTag('link', [
 				'rel' => 'canonical',
-				'content' => $canonical,
+				'href' => $canonical,
 			]);
 		}
 


### PR DESCRIPTION
Updated the canonical link to be the correct format eg. from 
`<link rel="canonical" content="http://www.example.com/product.html" />`
to
`<link rel="canonical" href="http://www.example.com/product.html" />`