### PR TITLE
Fluent Module Support

### DIFF
--- a/src/Fields/SEOEditor.php
+++ b/src/Fields/SEOEditor.php
@@ -191,11 +191,17 @@ class SEOEditor extends FormField
 
 	public function saveInto(DataObjectInterface $record)
 	{
-        if($this->isSavable()) {
+        if ($this->isSavable()) {
+            $dbObj = null;
             foreach($this->getFields() as $fieldName) {
                 if (isset($this->value[$fieldName])) {
-                    $record->setCastedField($fieldName, !empty($this->value[$fieldName]) ? $this->value[$fieldName] : null);
+                    $dbObj = $this->record->setCastedField($fieldName, !empty($this->value[$fieldName]) ? $this->value[$fieldName] : null);
                 }
+            }
+
+            // If Fluent is present, trigger a save to enable it to save to localised tables
+            if (class_exists('TractorCow\Fluent\Extension\FluentExtension') && $dbObj) {
+                $dbObj->write();
             }
         }
 	}


### PR DESCRIPTION
I've added an update that allows Fluent and SEO to work together. It feels a bit hacky triggering a save on the Record after the fields were supposedly already updated, but it appears to work well. I've set this functionality to only enable if Fluent is present to maintain current performance on any non-Fluent sites. Appreciate any suggestions or improvements.