### PR TITLE
small typo in fieldname

### DIFF
--- a/src/Extension/SiteConfigExtension.php
+++ b/src/Extension/SiteConfigExtension.php
@@ -69,7 +69,7 @@ class SiteConfigExtension extends DataExtension
         $fields->addFieldsToTab('Root.SEO.Embeds', [
             TextareaField::create('HeadScripts', 'Scripts within <head> block'),
             TextareaField::create('BodyStartScripts', 'Scripts just after opening <body>'),
-            TextareaField::create('BodyEndScripts', 'Scripts just before opening <body>')
+            TextareaField::create('BodyEndScripts', 'Scripts just before closing <body>')
         ]);
 
         $fields->addFieldsToTab('Root.SEO.Robots', [


### PR DESCRIPTION
Small (but confusing) typo in the naming of the embed-field `BodyEndScripts` 